### PR TITLE
In memory cache

### DIFF
--- a/src/main/java/org/ambraproject/rhombat/cache/GuavaCache.java
+++ b/src/main/java/org/ambraproject/rhombat/cache/GuavaCache.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 Public Library of Science
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package org.ambraproject.rhombat.cache;
+
+import com.google.common.cache.CacheBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.concurrent.TimeUnit;
+import com.google.common.cache.CacheLoader;
+import java.io.Serializable;
+
+public class GuavaCache implements Cache {
+  private static final Logger log = LoggerFactory.getLogger(GuavaCache.class);
+  com.google.common.cache.Cache<String, Object> cache;
+
+  public GuavaCache(int maximumSize) {
+    cache = CacheBuilder.newBuilder().maximumSize(maximumSize).build();
+  }
+
+  public GuavaCache() {
+    this(1000);
+  }
+
+  public void remove(String key) {
+    cache.invalidate(key);
+  }
+
+  public <T extends Serializable> void put(String key, T value, int timeout) {
+    put(key, value);
+  }
+
+  public <T extends Serializable> void put(String key, T value) {
+    cache.put(key, value);
+  }
+
+  @Override
+  public <T extends Serializable> T get(String key) {
+    return (T) cache.getIfPresent(key);
+  }
+}

--- a/src/test/java/org/ambraproject/rhombat/cache/GuavaCacheTest.java
+++ b/src/test/java/org/ambraproject/rhombat/cache/GuavaCacheTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Public Library of Science
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package org.ambraproject.rhombat.cache;
+
+import org.testng.annotations.Test;
+import java.util.ArrayList;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class GuavaCacheTest {
+  @Test
+  public void testCacheGet() {
+    GuavaCache cache = new GuavaCache();
+    cache.put("hello", "world");
+    assertEquals(cache.get("hello"), "world");
+  }
+
+  @Test
+  public void testCacheRemove() {
+    GuavaCache cache = new GuavaCache();
+    cache.put("hello", "world");
+    cache.remove("hello");
+    assertNull(cache.get("hello"));
+  }
+
+  @Test
+  public void testCacheEviction() {
+    GuavaCache cache = new GuavaCache(1);
+    cache.put("hello", "world");
+    cache.put("goodbye", "world");
+    assertNull(cache.get("hello"));
+    assertEquals(cache.get("goodbye"), "world");
+  }
+}


### PR DESCRIPTION
This allows the use of an in-memory cache in wombat as an alternative to memcached. This can help with local development or it can be used to simplify a production deployment.